### PR TITLE
Fixes #4: Passing the run name as an argument fails to find the run

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -139,37 +139,36 @@ func (cl *ConfigLoader) DiscoverRuns() ([]*RunConfig, error) {
 	return runs, nil
 }
 
-// FindRunByCategory finds a run configuration by category name
-func (cl *ConfigLoader) FindRunByCategory(runs []*RunConfig, category string) (*RunConfig, error) {
+// FindRunByName finds a run configuration by its name (exact or partial match)
+func (cl *ConfigLoader) FindRunByName(runs []*RunConfig, name string) (*RunConfig, error) {
 	var matches []*RunConfig
 
-	// Look for exact category matches
+	// Look for exact name matches
 	for _, run := range runs {
-		if strings.EqualFold(run.Category, category) {
+		if strings.EqualFold(run.Name, name) {
 			matches = append(matches, run)
 		}
 	}
 
 	// If no exact matches, try partial matches
 	if len(matches) == 0 {
-		lowerCategory := strings.ToLower(category)
+		lowerName := strings.ToLower(name)
 		for _, run := range runs {
-			if strings.Contains(strings.ToLower(run.Category), lowerCategory) {
+			if strings.Contains(strings.ToLower(run.Name), lowerName) {
 				matches = append(matches, run)
 			}
 		}
 	}
 
 	if len(matches) == 0 {
-		return nil, fmt.Errorf("no run found matching category '%s'", category)
+		return nil, fmt.Errorf("no run found matching name '%s'", name)
 	}
-
 	if len(matches) > 1 {
-		var categories []string
+		var names []string
 		for _, match := range matches {
-			categories = append(categories, match.Category)
+			names = append(names, match.Name)
 		}
-		return nil, fmt.Errorf("multiple runs found matching category '%s': %s", category, strings.Join(categories, ", "))
+		return nil, fmt.Errorf("multiple runs found matching name '%s': %s", name, strings.Join(names, ", "))
 	}
 
 	return matches[0], nil

--- a/internal/ui/cli.go
+++ b/internal/ui/cli.go
@@ -53,8 +53,8 @@ func (c *CLI) Start(runName string) error {
 	// Select run configuration
 	var selectedRun *config.RunConfig
 	if runName != "" {
-		// Find run by specified name/category
-		selectedRun, err = c.configLoader.FindRunByCategory(runs, runName)
+		// Find run by specified run name
+		selectedRun, err = c.configLoader.FindRunByName(runs, runName)
 		if err != nil {
 			c.printError(fmt.Sprintf("Run selection failed: %v", err))
 			c.printInfo("Available runs:")


### PR DESCRIPTION
Before:
```sh
❯ ./sni-autosplitter "A Link to the Past - Any% No Major Glitches"
┌─────────────────────────────────────────────────────────────┐
│                    SNI AutoSplitter                         │
│          LiveSplit One + Super Nintendo Interface           │
└─────────────────────────────────────────────────────────────┘

[INFO] Discovering run configurations...
[SUCCESS] Found 2 run configuration(s)
[ERROR] Run selection failed: no run found matching category 'A Link to the Past - Any% No Major Glitches'
[INFO] Available runs:
  1. A Link to the Past - Any% No Major Glitches (alttp - 15 splits)
  2. A Link to the Past - Master Sword No Major Glitches (alttp - 5 splits)
```

After:

```sh
❯ ./sni-autosplitter "A Link to the Past - Any% No Major Glitches"
┌─────────────────────────────────────────────────────────────┐
│                    SNI AutoSplitter                         │
│          LiveSplit One + Super Nintendo Interface           │
└─────────────────────────────────────────────────────────────┘

[INFO] Discovering run configurations...
[SUCCESS] Found 2 run configuration(s)
[SUCCESS] Selected run: Any% No Major Glitches
[INFO] Loading game configuration...
[SUCCESS] Loaded:  - Any% No Major Glitches (15 splits)
[INFO] Connecting to SNI server...
```