### PR TITLE
Fixes #5: SNI host and port arguments are ignored

### DIFF
--- a/cmd/sni-autosplitter/main.go
+++ b/cmd/sni-autosplitter/main.go
@@ -92,7 +92,7 @@ func runAutosplitter(cmd *cobra.Command, args []string) {
 	}
 
 	// Create and start the CLI interface
-	cliInterface := ui.NewCLI(logger, gamesDir, runsDir, enableManualOps)
+	cliInterface := ui.NewCLI(logger, gamesDir, runsDir, enableManualOps, sniHost, sniPort)
 
 	if err := cliInterface.Start(runName); err != nil {
 		logger.WithError(err).Fatal("Failed to start autosplitter")

--- a/internal/ui/device.go
+++ b/internal/ui/device.go
@@ -43,7 +43,7 @@ func (ds *DeviceSelector) SelectDevice(ctx context.Context) (*sni.Device, error)
 	if len(devices) == 0 {
 		ds.cli.printError("No compatible SNI devices found")
 		ds.cli.printInfo("Make sure:")
-		ds.cli.printInfo("  1. SNI is running (should be accessible at localhost:8191)")
+		ds.cli.printInfo(fmt.Sprintf("  1. SNI is running (should be accessible at %s:%d)", ds.cli.sniHost, ds.cli.sniPort))
 		ds.cli.printInfo("  2. Your SNES device is connected and detected by SNI")
 		ds.cli.printInfo("  3. The device supports memory reading")
 		return nil, fmt.Errorf("no compatible devices found")


### PR DESCRIPTION
Before:

```sh
❯ ./sni-autosplitter --sni-host 192.168.0.17 --sni-port 12345
┌─────────────────────────────────────────────────────────────┐
│                    SNI AutoSplitter                         │
│          LiveSplit One + Super Nintendo Interface           │
└─────────────────────────────────────────────────────────────┘

[INFO] Discovering run configurations...
[SUCCESS] Found 2 run configuration(s)
[INFO] Available runs:
  1. A Link to the Past - Any% No Major Glitches (alttp - 15 splits)
  2. A Link to the Past - Master Sword No Major Glitches (alttp - 5 splits)

Select run (1-2) or 'q' to quit: 2
[SUCCESS] Selected: Master Sword No Major Glitches
[INFO] Loading game configuration...
[SUCCESS] Loaded:  - Master Sword No Major Glitches (5 splits)
[INFO] Connecting to SNI server...
[ERROR] Failed to connect to SNI: failed to connect to SNI after 3 attempts: failed to connect to SNI at localhost:8191: context deadline exceeded
[INFO] Make sure SNI is running and accessible at localhost:8191
```

After:

```sh
❯ ./sni-autosplitter --sni-host 192.168.0.17 --sni-port 12345
┌─────────────────────────────────────────────────────────────┐
│                    SNI AutoSplitter                         │
│          LiveSplit One + Super Nintendo Interface           │
└─────────────────────────────────────────────────────────────┘

[INFO] Discovering run configurations...
[SUCCESS] Found 2 run configuration(s)
[INFO] Available runs:
  1. A Link to the Past - Any% No Major Glitches (alttp - 15 splits)
  2. A Link to the Past - Master Sword No Major Glitches (alttp - 5 splits)

Select run (1-2) or 'q' to quit: 2
[SUCCESS] Selected: Master Sword No Major Glitches
[INFO] Loading game configuration...
[SUCCESS] Loaded:  - Master Sword No Major Glitches (5 splits)
[INFO] Connecting to SNI server...
[SUCCESS] Connected to SNI server
[INFO] Discovering SNI devices...
[SUCCESS] Found 1 compatible device(s)
[INFO] Found device: MiSTer SNES (mister)
Use this device? (y/n): 
```