### PR TITLE
Fixes #6: Arguments can't be set with environment variables

### DIFF
--- a/cmd/sni-autosplitter/main.go
+++ b/cmd/sni-autosplitter/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"time"
+	"strings"
 
 	"github.com/jdharms/sni-autosplitter/internal/ui"
 	"github.com/spf13/cobra"
@@ -19,6 +20,7 @@ const (
 
 var (
 	// Command line flags
+	runName         string
 	gamesDir        string
 	runsDir         string
 	logDir          string
@@ -28,7 +30,7 @@ var (
 	enableManualOps bool
 
 	rootCmd = &cobra.Command{
-		Use:   "sni-autosplitter [run-name]",
+		Use:   "sni-autosplitter",
 		Short: "SNI-based autosplitter for LiveSplit One",
 		Long: `SNI AutoSplitter connects to SNI (Super Nintendo Interface) to read game memory
 and automatically trigger splits in LiveSplit One based on configurable conditions.
@@ -38,16 +40,29 @@ The autosplitter uses a two-tier configuration system:
 - Run configs define split sequences for specific categories
 
 Examples:
-  sni-autosplitter                    # Interactive mode - select from available runs
-  sni-autosplitter "alttp any% nmg"  # Load specific run by name
+  sni-autosplitter                              # Interactive mode - select from available runs
+  sni-autosplitter --run-name "alttp any% nmg"  # Load specific run by name
   sni-autosplitter --games-dir ./custom/games --runs-dir ./custom/runs`,
-		Args: cobra.MaximumNArgs(1),
+		Args: cobra.NoArgs,
 		Run:  runAutosplitter,
 	}
 )
 
 func init() {
+	// Override flag variables from env/flags before running
+	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		runName = viper.GetString("run-name")
+		gamesDir = viper.GetString("games-dir")
+		runsDir = viper.GetString("runs-dir")
+		logDir = viper.GetString("log-dir")
+		logLevel = viper.GetString("log-level")
+		sniHost = viper.GetString("sni-host")
+		sniPort = viper.GetInt("sni-port")
+		enableManualOps = viper.GetBool("enable-manual-ops")
+	}
+
 	// Set up command line flags
+	rootCmd.PersistentFlags().StringVar(&runName, "run-name", "", "Name of the run to load")
 	rootCmd.PersistentFlags().StringVar(&gamesDir, "games-dir", "./configs/games", "Directory containing game configuration files")
 	rootCmd.PersistentFlags().StringVar(&runsDir, "runs-dir", "./configs/runs", "Directory containing run configuration files")
 	rootCmd.PersistentFlags().StringVar(&logDir, "log-dir", "./logs", "Directory for log files")
@@ -56,14 +71,11 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&sniPort, "sni-port", 8191, "SNI gRPC server port")
 	rootCmd.PersistentFlags().BoolVar(&enableManualOps, "enable-manual-ops", false, "Enable manual split operations for development (split, reset, pause, resume, test)")
 
-	// Bind flags to viper
-	viper.BindPFlag("games-dir", rootCmd.PersistentFlags().Lookup("games-dir"))
-	viper.BindPFlag("runs-dir", rootCmd.PersistentFlags().Lookup("runs-dir"))
-	viper.BindPFlag("log-dir", rootCmd.PersistentFlags().Lookup("log-dir"))
-	viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level"))
-	viper.BindPFlag("sni-host", rootCmd.PersistentFlags().Lookup("sni-host"))
-	viper.BindPFlag("sni-port", rootCmd.PersistentFlags().Lookup("sni-port"))
-	viper.BindPFlag("enable-manual-ops", rootCmd.PersistentFlags().Lookup("enable-manual-ops"))
+	// Environment variable support and bind all flags
+	viper.SetEnvPrefix("sni_autosplitter")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viper.AutomaticEnv()
+	viper.BindPFlags(rootCmd.PersistentFlags())
 }
 
 func runAutosplitter(cmd *cobra.Command, args []string) {
@@ -76,6 +88,7 @@ func runAutosplitter(cmd *cobra.Command, args []string) {
 
 	logger.Info("SNI AutoSplitter starting up")
 	logger.WithFields(map[string]any{
+		"run-name":          runName,
 		"games-dir":         gamesDir,
 		"runs-dir":          runsDir,
 		"log-dir":           logDir,
@@ -84,13 +97,6 @@ func runAutosplitter(cmd *cobra.Command, args []string) {
 		"sni-port":          sniPort,
 		"enable-manual-ops": enableManualOps,
 	}).Info("Configuration loaded")
-
-	// Determine run name from args or interactive selection
-	var runName string
-	if len(args) > 0 {
-		runName = args[0]
-		logger.WithField("run", runName).Info("Run specified via command line")
-	}
 
 	// Create and start the CLI interface
 	cliInterface := ui.NewCLI(logger, gamesDir, runsDir, enableManualOps, sniHost, sniPort)


### PR DESCRIPTION
With this change, any argument can be set with an environment variable prefixes with SNI_AUTOSPLITTER_. The argument's - characters are replaced with _ characters.

For example: SNI_AUTOSPLITTER_SNI_HOST will set the --sni-host argument.

It also changes the run name argument from being positional to named.