### PR TITLE
Fixes #7: Resetting the MiSTer causes autostart to never evaluate

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -15,7 +15,7 @@ import (
 // Primitive manual testing of resetting a MiSTer has a threshold of about 1.25s where it
 // will fail to connect to the device after a reset. This default gives an extra second of
 // tolerance to account for other transient issues that may arise.
-const DefaultAutostartErrorTolerance = 2*time.Second + 250*time.Millisecond
+const DefaultErrorTolerance = 2*time.Second + 250*time.Millisecond
 
 // SplittingEngine manages the autosplitting logic and state
 type SplittingEngine struct {
@@ -26,15 +26,15 @@ type SplittingEngine struct {
 	session   *SplitterSession
 
 	// Configuration
-	pollInterval            time.Duration
-	autostartErrorTolerance time.Duration
+	pollInterval   time.Duration
+	errorTolerance time.Duration
 
 	// Runtime state
-	running             bool
-	ctx                 context.Context
-	cancel              context.CancelFunc
-	mu                  sync.RWMutex
-	autostartErrorStart time.Time
+	running    bool
+	ctx        context.Context
+	cancel     context.CancelFunc
+	mu         sync.RWMutex
+	errorStart time.Time
 
 	// Event subscribers
 	splitSubscribers  map[chan SplitEvent]struct{}
@@ -110,13 +110,10 @@ func (se *SplittingEngine) tick() error {
 
 // checkAutostart checks if the autostart condition is met
 func (se *SplittingEngine) checkAutostart() error {
-	// pick up the configured tolerance or fall back to the default
-	tol := se.autostartErrorTolerance
-	if tol == 0 {
-		tol = DefaultAutostartErrorTolerance
-	}
+	autostart := se.session.GetGameConfig().Autostart
+	autostartState := se.session.GetAutostartState()
 
-	result, err := se.evaluateAutostartWithTolerance(tol)
+	result, err := se.evaluateComplexConditionWithTolerance(&autostart, autostartState)
 	if err != nil {
 		return fmt.Errorf("failed to evaluate autostart condition: %w", err)
 	}
@@ -130,30 +127,6 @@ func (se *SplittingEngine) checkAutostart() error {
 	}
 
 	return nil
-}
-
-// evaluateAutostartWithTolerance suppresses errors until they persist beyond the tolerance window
-func (se *SplittingEngine) evaluateAutostartWithTolerance(tol time.Duration) (bool, error) {
-	autostart := se.session.GetGameConfig().Autostart
-	autostartState := se.session.GetAutostartState()
-
-	result, err := se.evaluator.EvaluateComplexCondition(se.ctx, se.device.URI, &autostart, autostartState)
-	if err != nil {
-		if se.autostartErrorStart.IsZero() {
-			se.autostartErrorStart = time.Now()
-		}
-		if time.Since(se.autostartErrorStart) > tol {
-			// reset so we don’t immediately re-error next tick
-			se.autostartErrorStart = time.Time{}
-			return false, err
-		}
-		// still within tolerance → suppress
-		return false, nil
-	}
-
-	// success → reset any previous error timestamp
-	se.autostartErrorStart = time.Time{}
-	return result, nil
 }
 
 // checkCurrentSplit checks if the current split condition is met
@@ -177,7 +150,8 @@ func (se *SplittingEngine) checkCurrentSplit() error {
 	splitState := se.session.GetSplitState(currentSplitName)
 
 	// Evaluate the split condition
-	result, err := se.evaluator.EvaluateComplexCondition(se.ctx, se.device.URI, split, splitState)
+	// apply tolerance logic for current split
+	result, err := se.evaluateComplexConditionWithTolerance(split, splitState)
 	if err != nil {
 		return fmt.Errorf("failed to evaluate split condition for '%s': %w", currentSplitName, err)
 	}
@@ -188,6 +162,32 @@ func (se *SplittingEngine) checkCurrentSplit() error {
 	}
 
 	return nil
+}
+
+// evaluateComplexConditionWithTolerance suppresses errors until they persist beyond the tolerance window
+func (se *SplittingEngine) evaluateComplexConditionWithTolerance(split *config.Split, splitState *SplitState) (bool, error) {
+	result, err := se.evaluator.EvaluateComplexCondition(se.ctx, se.device.URI, split, splitState)
+	if err != nil {
+		tol := se.errorTolerance
+		if tol == 0 {
+			tol = DefaultErrorTolerance
+		}
+
+		if se.errorStart.IsZero() {
+			se.errorStart = time.Now()
+		}
+		if time.Since(se.errorStart) > tol {
+			// reset so we don’t immediately re-error next tick
+			se.errorStart = time.Time{}
+			return false, err
+		}
+		// still within tolerance → suppress
+		return false, nil
+	}
+
+	// success → reset any previous error timestamp
+	se.errorStart = time.Time{}
+	return result, nil
 }
 
 // triggerSplit triggers a split and handles the transition

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -106,11 +106,9 @@ func (se *SplittingEngine) checkAutostart() error {
 	autostart := se.session.GetGameConfig().Autostart
 	autostartState := se.session.GetAutostartState()
 
-	result, err := se.evaluator.EvaluateComplexCondition(se.ctx, se.device.URI, &autostart, autostartState)
-	if err != nil {
-		return fmt.Errorf("failed to evaluate autostart condition: %w", err)
-	}
-
+	// Errors are intentionally ignored here. Resetting the SNES can cause errors due to memory not
+	// being readable, but ignoring the error allows the run loop to continue trying.
+	result, _ := se.evaluator.EvaluateComplexCondition(se.ctx, se.device.URI, &autostart, autostartState)
 	if result {
 		se.logger.Info("Autostart condition met - starting run")
 		se.session.Start()


### PR DESCRIPTION
When in the autostart state, failing to read memory is simply ignored. This happens when the MiSTer is reset. After it comes back up, memory reads work fine.

This is a very simple fix that appears to do the job, but I admit I don't know all of the possible error conditions.