### PR TITLE
Fixes #12: PollInterval is only 30 FPS instead of 60 FPS

### DIFF
--- a/cmd/sni-autosplitter/main.go
+++ b/cmd/sni-autosplitter/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/jdharms/sni-autosplitter/internal/ui"
 	"github.com/spf13/cobra"
@@ -13,7 +14,7 @@ const (
 	// LiveSplitOnePort is the WebSocket port for LiveSplit One connections
 	LiveSplitOnePort = 1990
 	// MemoryPollInterval is the interval between memory reads in milliseconds
-	MemoryPollInterval = 33
+	MemoryPollInterval = time.Second / 60 // 60 FPS
 )
 
 var (

--- a/internal/engine/config.go
+++ b/internal/engine/config.go
@@ -18,7 +18,7 @@ type EngineConfig struct {
 // DefaultEngineConfig returns the default engine configuration
 func DefaultEngineConfig() *EngineConfig {
 	return &EngineConfig{
-		PollInterval: time.Millisecond * 33, // ~30 FPS
+		PollInterval: time.Second / 60, // 60 FPS
 		BufferSize:   100,
 	}
 }


### PR DESCRIPTION
There will be a merge conflict with another #6 on line 6 of main.go. It adds "strings" on that line. Keeping both lines is the correct merge.