### PR TITLE
Add CI and release GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - run: go vet ./...
+      - run: go build ./...
+      - run: go test -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build and package all platforms
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          LDFLAGS="-s -w -X main.version=${VERSION}"
+
+          GOOS=linux   GOARCH=amd64 go build -trimpath -ldflags "${LDFLAGS}" -o sni-autosplitter     ./cmd/sni-autosplitter
+          tar czf sni-autosplitter-linux-amd64.tar.gz sni-autosplitter configs/
+          rm sni-autosplitter
+
+          GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "${LDFLAGS}" -o sni-autosplitter.exe ./cmd/sni-autosplitter
+          zip -r sni-autosplitter-windows-amd64.zip sni-autosplitter.exe configs/
+          rm sni-autosplitter.exe
+
+          GOOS=darwin  GOARCH=amd64 go build -trimpath -ldflags "${LDFLAGS}" -o sni-autosplitter     ./cmd/sni-autosplitter
+          tar czf sni-autosplitter-darwin-amd64.tar.gz sni-autosplitter configs/
+          rm sni-autosplitter
+
+          GOOS=darwin  GOARCH=arm64 go build -trimpath -ldflags "${LDFLAGS}" -o sni-autosplitter     ./cmd/sni-autosplitter
+          tar czf sni-autosplitter-darwin-arm64.tar.gz sni-autosplitter configs/
+          rm sni-autosplitter
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --generate-notes \
+            sni-autosplitter-linux-amd64.tar.gz \
+            sni-autosplitter-windows-amd64.zip \
+            sni-autosplitter-darwin-amd64.tar.gz \
+            sni-autosplitter-darwin-arm64.tar.gz

--- a/cmd/sni-autosplitter/main.go
+++ b/cmd/sni-autosplitter/main.go
@@ -19,6 +19,8 @@ const (
 )
 
 var (
+	version = "dev"
+
 	// Command line flags
 	runName         string
 	gamesDir        string
@@ -30,9 +32,10 @@ var (
 	enableManualOps bool
 
 	rootCmd = &cobra.Command{
-		Use:   "sni-autosplitter",
-		Short: "SNI-based autosplitter for LiveSplit One",
-		Long: `SNI AutoSplitter connects to SNI (Super Nintendo Interface) to read game memory
+		Use:     "sni-autosplitter",
+		Version: version,
+		Short:   "SNI-based autosplitter for LiveSplit One",
+		Long:    `SNI AutoSplitter connects to SNI (Super Nintendo Interface) to read game memory
 and automatically trigger splits in LiveSplit One based on configurable conditions.
 
 The autosplitter uses a two-tier configuration system:


### PR DESCRIPTION
- CI runs go vet, build, and test on push/PR to main
- Release workflow builds cross-platform binaries and publishes a GitHub release when a semver tag is pushed
- Embed version string in binary via ldflags at release time

```sh
$ ./sni-autosplitter --version
sni-autosplitter version v0.0.2
```

Example release from my fork: https://github.com/brantonb/sni-autosplitter/releases/tag/v0.0.2